### PR TITLE
Fixes RT#90922 Class::MOP::load_class deprecation warnings

### DIFF
--- a/META.yml
+++ b/META.yml
@@ -32,6 +32,7 @@ requires:
   Class::Data::Inheritable: 0
   Class::Inspector: 0
   Class::MOP: 0
+  Class::Load: 0.20
   DBD::SQLite: 1.14
   DBI: 1.4
   Data::Dump: 0

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -18,6 +18,7 @@ requires 'DateTime::Format::SQLite';
 
 requires 'Try::Tiny';
 requires 'Class::MOP';
+requires 'Class::Load' => 0.20;
 requires 'Class::Inspector';
 requires 'Class::Data::Inheritable';
 requires 'Data::Page' => 2.00;

--- a/lib/DBIx/ObjectMapper.pm
+++ b/lib/DBIx/ObjectMapper.pm
@@ -6,6 +6,7 @@ our $VERSION = '0.3018';
 
 use Carp::Clan qw/^DBIx::ObjectMapper/;
 use Params::Validate qw(:all);
+use Class::Load;
 
 use DBIx::ObjectMapper::Log;
 use DBIx::ObjectMapper::Utils;
@@ -83,8 +84,8 @@ sub relation {
         = $class
         . '::Relation::'
         . DBIx::ObjectMapper::Utils::camelize($rel_type);
-    Class::MOP::load_class($rel_class)
-        unless Class::MOP::is_class_loaded($rel_class);
+    Class::Load::load_class($rel_class)
+        unless Class::Load::is_class_loaded($rel_class);
     return $rel_class->new( @_ );
 }
 

--- a/lib/DBIx/ObjectMapper/Mapper/Attribute.pm
+++ b/lib/DBIx/ObjectMapper/Mapper/Attribute.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use Carp::Clan qw/^DBIx::ObjectMapper/;
 use Params::Validate qw(:all);
-use Class::MOP;
+use Class::Load;
 
 sub new {
     my $class  = shift;
@@ -40,8 +40,8 @@ sub new {
     }
 
     my $attribute_class = $class . '::' . $type;
-    Class::MOP::load_class($attribute_class)
-        unless Class::MOP::is_class_loaded($attribute_class);
+    Class::Load::load_class($attribute_class)
+        unless Class::Load::is_class_loaded($attribute_class);
     my $self = bless \%option, $attribute_class;
     $self->init;
 

--- a/lib/DBIx/ObjectMapper/Utils.pm
+++ b/lib/DBIx/ObjectMapper/Utils.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use Carp::Clan qw/^DBIx::ObjectMapper/;
 use Try::Tiny;
-use Class::MOP;
+use Class::Load;
 use Scalar::Util;
 use Hash::Merge;
 use Class::Inspector;
@@ -13,7 +13,7 @@ sub installed { Class::Inspector->installed($_[0]) }
 sub load_class {
     my $class_name = shift;
     return $class_name if loaded($class_name);
-    Class::MOP::load_class($class_name);
+    Class::Load::load_class($class_name);
 #    confess(
 #        "require $class_name was successful but the package is not defined")
 #      unless loaded($class_name);
@@ -21,7 +21,7 @@ sub load_class {
     return $class_name;
 }
 
-sub loaded { Class::MOP::is_class_loaded($_[0]) }
+sub loaded { Class::Load::is_class_loaded($_[0]) }
 
 sub is_deeply {
     my ( $X, $Y ) = @_;

--- a/t/10_meta/000_column_type.t
+++ b/t/10_meta/000_column_type.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
-use Class::MOP;
+use Class::Load;
 use DBIx::ObjectMapper::Engine::DBI;
 use DateTime::Format::SQLite;
 
@@ -12,7 +12,7 @@ $CHECK_BIT = 0 if $@;
 sub build_pkg($) {
     my $t = shift;
     my $pkg = 'DBIx::ObjectMapper::Metadata::Table::Column::Type::' . $t;
-    Class::MOP::load_class($pkg);
+    Class::Load::load_class($pkg);
     return $pkg;
 }
 


### PR DESCRIPTION
This fixes RT#90922: warnings produced by the deprecation of Class::MOP::load_class

See https://rt.cpan.org/Ticket/Display.html?id=90922
