### PR TITLE
fix exit status

### DIFF
--- a/t/20_misc/004_fork.t
+++ b/t/20_misc/004_fork.t
@@ -67,7 +67,7 @@ ok(!$@) or diag "Creation eval failed: $@";
     }
 
     if (!$pid) {
-        exit $cd->engine->connected ? 1 : 0;
+        exit($cd->engine->connected ? 1 : 0);
     }
 
     if (waitpid($pid, 0) == $pid) {


### PR DESCRIPTION
`exit` has higher precedence than `?:`, so `exit $connected ? 1 : 0` parses as `(exit $connected) ? 1 : 0`, which is not what was intended.